### PR TITLE
Add an idiomatic __main__ guard to gui.py

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -94,5 +94,5 @@ def main():
     Ui.start_serial_monitor(window)
     app.exec_()
 
-
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This means that if, in future, we want to import anything from `gui.py`, it won't create a new GUI window without us explicitly importing and calling `main()`. Running gui.py directly still works.